### PR TITLE
Add feature flag to enable scroll/std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ harness = false
 alloc = []
 crypto = ["dep:pbkdf2", "dep:hmac", "dep:sha1"]
 default = ["crypto"]
+std = ["alloc", "scroll/std"]


### PR DESCRIPTION
`scroll::Error` implements `std::error::Error` only if the `std` feature is enabled. By adding a feature flag here, we can format errors without adding `scroll` in dependent crates just to enable the flag.