### PR TITLE
Element impl for VendorSpecificElement generic over Payload

### DIFF
--- a/src/elements/vendor_specific_element.rs
+++ b/src/elements/vendor_specific_element.rs
@@ -73,7 +73,9 @@ impl<Payload: TryIntoCtx<Error = scroll::Error>> TryIntoCtx for VendorSpecificEl
         Ok(offset)
     }
 }
-impl<'a> Element for VendorSpecificElement<'a> {
+impl<'a, Payload: MeasureWith<()> + TryIntoCtx<Error = scroll::Error>> Element
+    for VendorSpecificElement<'a, Payload>
+{
     const ELEMENT_ID: ElementID = ElementID::Id(0xdd);
     type ReadType<'b> = VendorSpecificElement<'b>;
 }


### PR DESCRIPTION
Fix `VendorSpecificElement` when created with `new_prefixed` doesn't implement `Element` because the payload isn't `&'a [u8]` it's `PrefixedVendorPayload<&'a [u8]>`.

Enables using the `VendorSpecificElement` in an `element_chain!` with `pwrite`