### PR TITLE
fix: don't depend on defmt if feature unset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ const_soft_float = { version = "0.1.4", features = ["no_std"] }
 crc32fast = { version = "1.3.2", default-features = false }
 defmt = { version = "0.3.8", optional = true }
 hmac = { version = "0.12.1", optional = true }
-mac-parser = { version = "0.1.6", features = ["defmt"] }
+mac-parser = { version = "0.1.6" }
 macro-bits = "0.1.4"
 num = { version = "0.4.3", default-features = false }
 pbkdf2 = { version = "0.12.2", optional = true }
@@ -36,4 +36,4 @@ alloc = []
 crypto = ["dep:pbkdf2", "dep:hmac", "dep:sha1"]
 default = ["crypto"]
 std = ["alloc", "scroll/std"]
-defmt = ["dep:defmt"]
+defmt = ["dep:defmt", "mac-parser/defmt"]


### PR DESCRIPTION
Got a link error because `defmt` was in tree but had no implementation for it.